### PR TITLE
Override default curl timeout to account for API GW

### DIFF
--- a/src/Braket.jl
+++ b/src/Braket.jl
@@ -65,7 +65,10 @@ const Prices = Ref{Pricing}()
 const GlobalTrackerContext = Ref{TrackerContext}()
 
 function __init__()
+    downloader = Downloads.Downloader()
+    downloader.easy_hook = (easy, info) -> Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_LOW_SPEED_TIME, 60)
     AWS.DEFAULT_BACKEND[] = AWS.DownloadsBackend()
+    AWS.AWS_DOWNLOADER[] = downloader
     IRType[] = :OpenQASM
     Prices[] = Pricing([])
     GlobalTrackerContext[] = TrackerContext()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increase the timeout for `curl` so that API GW requests (which can take longer than 30s to respond) do not time out.

*Testing done:*

Fixed timeout issues for big circuits locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/awslabs/braket-jl/blob/main/README.md) and [API docs](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have installed and run [`git secrets`](https://github.com/awslabs/git-secrets) to make sure I did not commit any sensitive information (passwords or credentials)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
