### PR TITLE
fix: properly support IonQ native gates and add various tests

### DIFF
--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -293,7 +293,7 @@ Program(c::Circuit) = convert(Program, c)
 
 function openqasm_header(c::Circuit, sps::SerializationProperties=OpenQASMSerializationProperties())
     ir_instructions = ["OPENQASM 3.0;"]
-    for p in c.parameters
+    for p in sort(string.(c.parameters))
         push!(ir_instructions, "input float $p;")
     end
     isempty(c.result_types) && push!(ir_instructions, "bit[$(qubit_count(c))] b;")

--- a/src/gates.jl
+++ b/src/gates.jl
@@ -28,7 +28,7 @@ abstract type DoubleAngledGate <: Gate end
 
 StructTypes.StructType(::Type{DoubleAngledGate}) = StructTypes.AbstractType()
  
-StructTypes.subtypes(::Type{DoubleAngledGate}) = (ms=MS)
+StructTypes.subtypes(::Type{DoubleAngledGate}) = (ms=MS,)
 for (G, IRG, label, qc) in zip((:Rx, :Ry, :Rz, :PhaseShift, :PSwap, :XY, :CPhaseShift, :CPhaseShift00, :CPhaseShift01, :CPhaseShift10, :XX, :YY, :ZZ, :GPi, :GPi2), (:(IR.Rx), :(IR.Ry), :(IR.Rz), :(IR.PhaseShift), :(IR.PSwap), :(IR.XY), :(IR.CPhaseShift), :(IR.CPhaseShift00), :(IR.CPhaseShift01), :(IR.CPhaseShift10), :(IR.XX), :(IR.YY), :(IR.ZZ), :(IR.GPi), :(IR.GPi2)), ("rx", "ry", "rz", "phaseshift", "pswap", "xy", "cphaseshift", "cphaseshift00", "cphaseshift01", "cphaseshift10", "xx", "yy", "zz", "gpi", "gpi2"), (:1, :1, :1, :1, :2, :2, :2, :2, :2, :2, :2, :2, :2, :1, :1))
     @eval begin
         @doc """

--- a/src/raw_schema.jl
+++ b/src/raw_schema.jl
@@ -119,7 +119,7 @@ export Program, AHSProgram, AbstractIR, AbstractProgramResult, CompilerDirective
 abstract type AbstractIR end
 StructTypes.StructType(::Type{AbstractIR}) = StructTypes.AbstractType()
 StructTypes.subtypekey(::Type{AbstractIR}) = :type
-StructTypes.subtypes(::Type{AbstractIR})   = (z=Z, sample=Sample, cphaseshift01=CPhaseShift01, phase_damping=PhaseDamping, rz=Rz, generalized_amplitude_damping=GeneralizedAmplitudeDamping, xx=XX, zz=ZZ, phase_flip=PhaseFlip, vi=Vi, depolarizing=Depolarizing, variance=Variance, two_qubit_depolarizing=TwoQubitDepolarizing, densitymatrix=DensityMatrix, cphaseshift00=CPhaseShift00, ecr=ECR, compilerdirective=CompilerDirective, ccnot=CCNot, unitary=Unitary, bit_flip=BitFlip, y=Y, swap=Swap, cz=CZ, cnot=CNot, adjoint_gradient=AdjointGradient, cswap=CSwap, ry=Ry, i=I, si=Si, amplitude_damping=AmplitudeDamping, statevector=StateVector, iswap=ISwap, h=H, xy=XY, yy=YY, t=T, two_qubit_dephasing=TwoQubitDephasing, x=X, ti=Ti, cv=CV, pauli_channel=PauliChannel, pswap=PSwap, expectation=Expectation, probability=Probability, phaseshift=PhaseShift, v=V, cphaseshift=CPhaseShift, s=S, rx=Rx, kraus=Kraus, amplitude=Amplitude, cphaseshift10=CPhaseShift10, multi_qubit_pauli_channel=MultiQubitPauliChannel, cy=CY, setup=Setup, hamiltonian=Hamiltonian, shiftingfield=ShiftingField, atomarrangement=AtomArrangement, timeseries=TimeSeries, physicalfield=PhysicalField, ahsprogram=AHSProgram, drivingfield=DrivingField, abstractprogramresult=AbstractProgramResult)
+StructTypes.subtypes(::Type{AbstractIR})   = (z=Z, sample=Sample, cphaseshift01=CPhaseShift01, phase_damping=PhaseDamping, rz=Rz, generalized_amplitude_damping=GeneralizedAmplitudeDamping, xx=XX, zz=ZZ, phase_flip=PhaseFlip, vi=Vi, depolarizing=Depolarizing, variance=Variance, two_qubit_depolarizing=TwoQubitDepolarizing, densitymatrix=DensityMatrix, cphaseshift00=CPhaseShift00, ecr=ECR, compilerdirective=CompilerDirective, ccnot=CCNot, unitary=Unitary, bit_flip=BitFlip, y=Y, swap=Swap, cz=CZ, cnot=CNot, adjoint_gradient=AdjointGradient, cswap=CSwap, ry=Ry, i=I, si=Si, amplitude_damping=AmplitudeDamping, statevector=StateVector, iswap=ISwap, h=H, xy=XY, yy=YY, t=T, two_qubit_dephasing=TwoQubitDephasing, x=X, ti=Ti, cv=CV, pauli_channel=PauliChannel, pswap=PSwap, ms=MS, gpi=GPi, gpi2=GPi2, expectation=Expectation, probability=Probability, phaseshift=PhaseShift, v=V, cphaseshift=CPhaseShift, s=S, rx=Rx, kraus=Kraus, amplitude=Amplitude, cphaseshift10=CPhaseShift10, multi_qubit_pauli_channel=MultiQubitPauliChannel, cy=CY, setup=Setup, hamiltonian=Hamiltonian, shiftingfield=ShiftingField, atomarrangement=AtomArrangement, timeseries=TimeSeries, physicalfield=PhysicalField, ahsprogram=AHSProgram, drivingfield=DrivingField, abstractprogramresult=AbstractProgramResult)
 
 const IRObservable = Union{Vector{Union{String, Vector{Vector{Vector{Float64}}}}}, String}
 Base.convert(::Type{IRObservable}, v::Vector{String}) = convert(Vector{Union{String, Vector{Vector{Vector{Float64}}}}}, v)
@@ -522,6 +522,32 @@ end
 StructTypes.StructType(::Type{PSwap}) = StructTypes.UnorderedStruct()
 
 StructTypes.defaults(::Type{PSwap}) = Dict{Symbol, Any}(:type => "pswap")
+
+struct MS <: AbstractIR
+    angle1::Float64
+    angle2::Float64
+    targets::Vector{Int}
+    type::String
+end
+StructTypes.StructType(::Type{MS}) = StructTypes.UnorderedStruct()
+
+struct GPi <: AbstractIR
+    angle::Float64
+    target::Int
+    type::String
+end
+StructTypes.StructType(::Type{GPi}) = StructTypes.UnorderedStruct()
+
+StructTypes.defaults(::Type{GPi}) = Dict{Symbol, Any}(:type => "gpi")
+
+struct GPi2 <: AbstractIR
+    angle::Float64
+    target::Int
+    type::String
+end
+StructTypes.StructType(::Type{GPi2}) = StructTypes.UnorderedStruct()
+
+StructTypes.defaults(::Type{GPi2}) = Dict{Symbol, Any}(:type => "gpi2")
 struct Expectation <: AbstractProgramResult
     observable::IRObservable
     targets::Union{Nothing, Vector{Int}}
@@ -641,7 +667,7 @@ for g in [:CCNot]
 end
 abstract type Target end
 struct SingleTarget <: Target end
-for g in [:H, :I, :X, :Y, :Z, :Rx, :Ry, :Rz, :S, :T, :Si, :Ti, :PhaseShift, :CPhaseShift, :CPhaseShift00, :CPhaseShift01, :CPhaseShift10, :CNot, :CCNot, :CV, :CY, :CZ, :V, :Vi, :BitFlip, :PhaseFlip, :PauliChannel, :Depolarizing, :AmplitudeDamping, :GeneralizedAmplitudeDamping, :PhaseDamping]
+for g in [:H, :I, :X, :Y, :Z, :Rx, :Ry, :Rz, :S, :T, :Si, :Ti, :PhaseShift, :CPhaseShift, :CPhaseShift00, :CPhaseShift01, :CPhaseShift10, :CNot, :CCNot, :CV, :CY, :CZ, :V, :Vi, :GPi, :GPi2, :BitFlip, :PhaseFlip, :PauliChannel, :Depolarizing, :AmplitudeDamping, :GeneralizedAmplitudeDamping, :PhaseDamping]
     @eval begin
         Target(::Type{$g}) = SingleTarget()
     end
@@ -659,7 +685,7 @@ for g in [:AdjointGradient]
     end
 end
 struct DoubleTarget <: Target end
-for g in [:Swap, :CSwap, :ISwap, :PSwap, :XY, :ECR, :XX, :YY, :ZZ, :TwoQubitDepolarizing, :TwoQubitDephasing]
+for g in [:Swap, :CSwap, :ISwap, :PSwap, :XY, :ECR, :XX, :YY, :ZZ, :MS, :TwoQubitDepolarizing, :TwoQubitDephasing]
     @eval begin
         Target(::Type{$g}) = DoubleTarget()
     end
@@ -684,9 +710,14 @@ abstract type Angle end
 struct DoubleAngled <: Angle end
 struct Angled <: Angle end
 struct NonAngled <: Angle end
-for g in [:Rx, :Ry, :Rz, :PhaseShift, :CPhaseShift, :CPhaseShift00, :CPhaseShift01, :CPhaseShift10, :PSwap, :XY, :XX, :YY, :ZZ]
+for g in [:Rx, :Ry, :Rz, :PhaseShift, :CPhaseShift, :CPhaseShift00, :CPhaseShift01, :CPhaseShift10, :PSwap, :XY, :XX, :YY, :ZZ, :GPi, :GPi2]
     @eval begin
         Angle(::Type{$g}) = Angled()
+    end
+end
+for g in [:MS]
+    @eval begin
+        Angle(::Type{$g}) = DoubleAngled()
     end
 end
 Angle(::Type{G}) where {G<:AbstractIR} = NonAngled()

--- a/test/gates.jl
+++ b/test/gates.jl
@@ -86,6 +86,27 @@ T_mat = round.(reduce(hcat, [[1.0, 0], [0, 0.70710678 + 0.70710678im]]), digits=
         pg = g(α)
         @test Braket.parameters(pg) == [α]
     end
+    @testset for g in (MS(angle, angle),)
+        @test qubit_count(g) == 2
+        ix = Instruction(g, [0, 1])
+        @test JSON3.read(JSON3.write(ix), Instruction) == ix
+        @test Braket.Parametrizable(g) == Braket.Parametrized()
+        @test Braket.parameters(g) == Braket.FreeParameter[]
+    end
+    @testset for g in (MS,)
+        @test qubit_count(g) == 2
+        c = Circuit()
+        c = g(c, 0, 1, angle, angle)
+        @test c.instructions == [Instruction(g(angle, angle), [0, 1])]
+        c = Circuit()
+        c = g(c, 10, 1, angle, angle)
+        @test c.instructions == [Instruction(g(angle, angle), [10, 1])]
+        α = FreeParameter(:alpha)
+        β = FreeParameter(:beta)
+        pg = g(α, β)
+        @test Braket.parameters(pg) == [α, β]
+        pg = Braket.bind_value!(Braket.Parametrized(), pg, Dict{Symbol, Number}(:α=>0.1, :β=>0.5))
+    end
     @testset for g in (CCNot(), CSwap())
         @test qubit_count(g) == 3
         ix = Instruction(g, [0, 1, 2])

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -89,6 +89,7 @@ using Braket: operator, target
         @test parsed.basis_rotation_instructions       == raw.basis_rotation_instructions
         @test Braket.parse_raw_schema(JSON3.write(raw)) == raw
         p = Braket.Program(Circuit(raw))
+        @test qubit_count(p) == qubit_count(Circuit(raw))
         for (pix, rix) in zip(p.instructions, raw.instructions)
             @test pix == rix
         end


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Add support in IR module for the IonQ gates so they can be properly applied. Also add a variety of other small tests. Parameters are now written in sorted order to OpenQASM headers.

*Testing done:*

Unit tests passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/awslabs/braket-jl/blob/main/README.md) and [API docs](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have installed and run [`git secrets`](https://github.com/awslabs/git-secrets) to make sure I did not commit any sensitive information (passwords or credentials)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
