### PR TITLE
fix: qubit printing to OpenQASM and handling of OpenQasmProgram inputs

### DIFF
--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -176,6 +176,7 @@ end
 (c::Circuit)(::Type{T}, args...) where {T<:Noise} = apply_noise!(T, c, args...)
 (c::Circuit)(::Type{T}) where {T<:CompilerDirective} = add_instruction!(c, Instruction(T()))
 (c::Circuit)(g::QuantumOperator, args...) = add_instruction!(c, Instruction(g, args...))
+(c::Circuit)(g::CompilerDirective) = add_instruction!(c, Instruction(g))
 (c::Circuit)(v::AbstractVector) = foreach(vi->c(vi...), v)
 (c::Circuit)(rt::Result, args...) = add_result_type!(c, rt, args...)
 (c::Circuit)(::Type{T}, args...) where {T<:Result} = T(c, args...)

--- a/src/compiler_directive.jl
+++ b/src/compiler_directive.jl
@@ -27,7 +27,7 @@ ir(s::StartVerbatimBox, ::Val{:JAQCD}; kwargs...)    = IR.StartVerbatimBox("Star
 ir(s::EndVerbatimBox,   ::Val{:JAQCD}; kwargs...)    = IR.EndVerbatimBox("EndVerbatimBox", "end_verbatim_box")
 ir(s::StartVerbatimBox, ::Val{:OpenQASM}; kwargs...) = "#pragma braket verbatim\nbox{"
 ir(s::EndVerbatimBox,   ::Val{:OpenQASM}; kwargs...) = "}"
-ir(c::CompilerDirective)                       = ir(c, Val(:JAQCD))
+ir(c::CompilerDirective; kwargs...)                  = ir(c, IRType[]; kwargs...)
 chars(s::StartVerbatimBox) = ("StartVerbatim","StartVerbatim")
 chars(s::EndVerbatimBox)   = ("EndVerbatim","EndVerbatim")
 

--- a/src/irtypes.jl
+++ b/src/irtypes.jl
@@ -13,9 +13,9 @@ Base.@kwdef struct OpenQASMSerializationProperties <: SerializationProperties
     qubit_reference_type::QubitReferenceType=VIRTUAL
 end
 
-format(target::Int, sps::OpenQASMSerializationProperties) = sps.qubit_reference_type == VIRTUAL ? "q[$target]" : "\$$target"
-format(target::Qubit, sps::OpenQASMSerializationProperties) = sps.qubit_reference_type == VIRTUAL ? "q[$target]" : "\$$target"
-format_qubits(qubits, sps::OpenQASMSerializationProperties) = chop(prod(map(q->format(q, sps), vcat(qubits...)) .* ", "), tail=2)
+format(target::Int, sps::OpenQASMSerializationProperties)   = sps.qubit_reference_type == VIRTUAL ? "q[$target]" : "\$$target"
+format(target::Qubit, sps::OpenQASMSerializationProperties) = format(Int(target), sps)
+format_qubits(qubits, sps::OpenQASMSerializationProperties) = join(map(q->format(q, sps), vcat(qubits...)), ", ")
 function format_complex(n::Number)
     iszero(real(n)) && iszero(imag(n)) && return 0
     isreal(n) && return real(n)

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -175,7 +175,7 @@ function ir(ho::HermitianObservable, target::QubitSet, ::Val{:OpenQASM}; seriali
     t = isempty(target) ? "all" : format_qubits(target, serialization_properties)
     return "hermitian($m) $t"
 end
-Base.:(*)(o::HermitianObservable, n::Real) = HermitianObservable(Float64(n) .* o.matrix, 1.0)
+Base.:(*)(o::HermitianObservable, n::Real) = HermitianObservable(Float64(n) .* o.matrix)
 ir(ho::HermitianObservable, target::Nothing, ::Val{:OpenQASM}; kwargs...) = ir(ho, QubitSet(), Val(:OpenQASM); kwargs...)
 chars(o::HermitianObservable) = ("Hermitian",)
 

--- a/src/raw_schema.jl
+++ b/src/raw_schema.jl
@@ -10,7 +10,7 @@ abstract type BraketSchemaBase end
 
 StructTypes.StructType(::Type{BraketSchemaBase}) = StructTypes.AbstractType()
 StructTypes.subtypekey(::Type{BraketSchemaBase}) = :braketSchemaHeader
- 
+
 
 struct braketSchemaHeader
     name::String

--- a/src/task.jl
+++ b/src/task.jl
@@ -156,7 +156,8 @@ function prepare_task_input(program::OpenQasmProgram, device_arn::String, s3_fol
     
     inputs = get(kwargs, :inputs, Dict{String, Float64}())
     if !isempty(inputs)
-        inputs_merged = merge(program.inputs, inputs)
+        prog_inputs = isnothing(program.inputs) ? Dict{String, Float64}() : program.inputs
+        inputs_merged = merge(prog_inputs, inputs)
         program_ = OpenQasmProgram(program.braketSchemaHeader, program.source, inputs_merged)
         action   = JSON3.write(program_)
     else

--- a/test/gate_model_task_result.jl
+++ b/test/gate_model_task_result.jl
@@ -70,7 +70,12 @@ end
                             [Braket.IR.CNot(0, 1, "cnot"), Braket.IR.CNot(2, 3, "cnot")],
                             [Braket.IR.Probability([1], "probability"),
                              Braket.IR.Expectation(["z"], nothing, "expectation"),
-                             Braket.IR.Variance(["x", "x"], [0, 2], "variance"), samp],
+                             Braket.IR.Variance(["x", "x"], [0, 2], "variance"),
+                             samp,
+                             Braket.IR.Sample(["z"], [1], "sample"),
+                             Braket.IR.Sample(["x", "y"], [1, 2], "sample"),
+                             Braket.IR.Sample(["z"], nothing, "sample"),
+                            ],
                             [])
     task_metadata_shots = Braket.TaskMetadata(Braket.header_dict[Braket.TaskMetadata], "task_arn", length(measurements), "arn1", nothing, nothing, nothing, nothing, nothing)
     additional_metadata = Braket.AdditionalMetadata(action, nothing, nothing, nothing, nothing, nothing, nothing)
@@ -89,6 +94,29 @@ end
     @test quantum_task_result.values[4] ≈ [1.0, 1.0, -1.0, 1.0, 1.0, 1.0, -1.0, 1.0, -1.0, -1.0]
     @test quantum_task_result.result_types[1].type == Braket.IR.Probability([1], "probability")
     @test quantum_task_result.result_types[2].type == Braket.IR.Expectation(["z"], nothing, "expectation")
+    
+
+    action = Braket.Program(Braket.header_dict[Braket.Program],
+                            [Braket.IR.H(0, "h"), Braket.IR.H(1, "h"), Braket.IR.H(2, "h"), Braket.IR.H(3, "h")],
+                            [Braket.IR.Sample(["z"], [1], "sample"),
+                             Braket.IR.Sample(["x", "y"], [1, 2], "sample"),
+                             Braket.IR.Sample(["z"], nothing, "sample"),
+                            ],
+                            [])
+    task_metadata_shots = Braket.TaskMetadata(Braket.header_dict[Braket.TaskMetadata], "task_arn", length(measurements), "arn1", nothing, nothing, nothing, nothing, nothing)
+    additional_metadata = Braket.AdditionalMetadata(action, nothing, nothing, nothing, nothing, nothing, nothing)
+    task_result = Braket.GateModelTaskResult(Braket.header_dict[Braket.GateModelTaskResult],
+        measurements,
+        nothing,
+        nothing,
+        [0, 1, 2, 3],
+        task_metadata_shots,
+        additional_metadata,
+    )
+    quantum_task_result = Braket.format_result(task_result)
+    @test quantum_task_result.values[1] ≈ [1, -1, 1, 1, -1, -1, 1, -1, 1, 1]
+    @test quantum_task_result.values[2] ≈ [-1, 1, 1, -1, 1, 1, 1, 1, 1, 1]
+    @test quantum_task_result.values[3] ≈ [[1, -1, -1, 1, -1, 1, 1, 1, 1, 1], [1, -1, 1, 1, -1, -1, 1, -1, 1, 1], [-1, -1, 1, -1, -1, -1, 1, -1, 1, 1], [1, -1, -1, 1, -1, -1, -1, -1, 1, -1]] 
 
     @testset "result without measurements or measurementProbabilities" begin
         task_metadata_shots = Braket.TaskMetadata(Braket.header_dict[Braket.TaskMetadata], "task_arn", length(measurements), "arn1", nothing, nothing, nothing, nothing, nothing)

--- a/test/gates.jl
+++ b/test/gates.jl
@@ -170,7 +170,9 @@ T_mat = round.(reduce(hcat, [[1.0, 0], [0, 0.70710678 + 0.70710678im]]), digits=
     @testset "OpenQASM IR" begin
         fp  = FreeParameter(:alpha)
         fp2 = FreeParameter(:beta)
-        @testset for ir_bolus in [ 
+        @testset for ir_bolus in [
+            (Rx(0.17), [Qubit(4)], OpenQASMSerializationProperties(qubit_reference_type=VIRTUAL), "rx(0.17) q[4];",),
+            (Rx(0.17), [Qubit(4)], OpenQASMSerializationProperties(qubit_reference_type=PHYSICAL), "rx(0.17) \$4;",),
             (Rx(0.17), [4], OpenQASMSerializationProperties(qubit_reference_type=VIRTUAL), "rx(0.17) q[4];",),
             (Rx(0.17), [4], OpenQASMSerializationProperties(qubit_reference_type=PHYSICAL), "rx(0.17) \$4;",),
             (X(), [4], OpenQASMSerializationProperties(qubit_reference_type=VIRTUAL), "x q[4];",),

--- a/test/observables.jl
+++ b/test/observables.jl
@@ -17,6 +17,8 @@ using LinearAlgebra: eigvals
         rt = Expectation(o, [0])
         @test JSON3.read(JSON3.write(rt), Braket.Result) == rt
         @test ir(o) isa IRObservable
+        mult_h = 2.0 * o
+        @test mult_h.matrix == 2.0 * m
     end
     @testset "TensorProduct" begin
         tp = Observables.TensorProduct(["x", "y", "z"])
@@ -129,6 +131,7 @@ using LinearAlgebra: eigvals
             ( Observables.HermitianObservable(diagm(ones(Int64, 4))), OpenQASMSerializationProperties(qubit_reference_type=VIRTUAL), [1, 2], "hermitian([[1+0im, 0im, 0im, 0im], [0im, 1+0im, 0im, 0im], [0im, 0im, 1+0im, 0im], [0im, 0im, 0im, 1+0im]]) q[1], q[2]"),
             ( Observables.HermitianObservable(diagm(ones(Int64, 4))), OpenQASMSerializationProperties(qubit_reference_type=PHYSICAL), [1, 2], "hermitian([[1+0im, 0im, 0im, 0im], [0im, 1+0im, 0im, 0im], [0im, 0im, 1+0im, 0im], [0im, 0im, 0im, 1+0im]]) \$1, \$2"),
             ( Observables.HermitianObservable(diagm(ones(Int64, 2))), OpenQASMSerializationProperties(qubit_reference_type=VIRTUAL), nothing, "hermitian([[1+0im, 0im], [0im, 1+0im]]) all"),
+            ( Observables.HermitianObservable([1 1-im; 1+im 1]), OpenQASMSerializationProperties(qubit_reference_type=VIRTUAL), nothing, "hermitian([[1+0im, 1-1im], [1+1im, 1+0im]]) all"),
             ( Observables.TensorProduct([Observables.H(), Observables.Z()]), OpenQASMSerializationProperties(qubit_reference_type=VIRTUAL), [3, 0], "h(q[3]) @ z(q[0])"),
             ( Observables.TensorProduct([Observables.H(), Observables.Z()]), OpenQASMSerializationProperties(qubit_reference_type=PHYSICAL), [3, 0], "h(\$3) @ z(\$0)"),
             ( Observables.TensorProduct([Observables.H(), Observables.Z(), Observables.I()]), OpenQASMSerializationProperties(qubit_reference_type=VIRTUAL), [3, 0, 1], "h(q[3]) @ z(q[0]) @ i(q[1])"),


### PR DESCRIPTION

*Issue #, if available:*

N/A

*Description of changes:*

Fix formatting of `Qubit` types when printing IR to OQ3. Fix handling of inputs in the case that an `OpenQasmProgram` has `nothing` in its `inputs` field. Added more tests and fixed a whitespace.

*Testing done:*

Tests pass locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/awslabs/braket-jl/blob/main/README.md) and [API docs](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have installed and run [`git secrets`](https://github.com/awslabs/git-secrets) to make sure I did not commit any sensitive information (passwords or credentials)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
